### PR TITLE
Allow skip destructor in the binding configuration

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1003,6 +1003,7 @@ class NativeClass(object):
         self.cursor = cursor
         self.class_name = cursor.displayname
         self.is_ref_class = self.class_name == "Ref"
+        self.is_skip_destructor = generator.skip_destructor(self.class_name)
         self.namespaced_class_name = self.class_name
         self.parents = []
         self.fields = []
@@ -1447,6 +1448,9 @@ class Generator(object):
                                     print "Field %s of %s will be bound" % (field_name, class_name)
                                 return True
         return False
+
+    def skip_destructor(self, class_name):
+        return self.should_skip(class_name, "~" + class_name)
 
     def in_listed_classes(self, class_name):
         """

--- a/generator.py
+++ b/generator.py
@@ -1335,7 +1335,7 @@ class Generator(object):
                         #simply pickup first installed clang version
                         clang_arg = os.path.join(clang_versions, clang_folders[0], "include")
                         extend_clang_args.append("-I"+clang_arg)
-                        print("  => apend %s"%clang_arg)
+                        print("  => append %s"%clang_arg)
 
         if len(extend_clang_args) > 0:
             self.clang_args.extend(extend_clang_args)

--- a/targets/spidermonkey/templates/register.c
+++ b/targets/spidermonkey/templates/register.c
@@ -65,12 +65,12 @@ static bool js_${current_class.underlined_class_name}_destroy(se::State& s)
         delete cobj;
     }
         #end if
+    #end if
     auto objIter = se::NativePtrToObjectMap::find(s.nativeThisObject());
     if(objIter != se::NativePtrToObjectMap::end())
     {
         objIter->second->clearPrivateData(true);
     }
-    #end if
     return true;
 }
 SE_BIND_FUNC(js_${current_class.underlined_class_name}_destroy)

--- a/targets/spidermonkey/templates/register.c
+++ b/targets/spidermonkey/templates/register.c
@@ -65,6 +65,11 @@ static bool js_${current_class.underlined_class_name}_destroy(se::State& s)
         delete cobj;
     }
         #end if
+    auto objIter = se::NativePtrToObjectMap::find(s.nativeThisObject());
+    if(objIter != se::NativePtrToObjectMap::end())
+    {
+        objIter->second->clearPrivateData(true);
+    }
     #end if
     return true;
 }

--- a/targets/spidermonkey/templates/register.c
+++ b/targets/spidermonkey/templates/register.c
@@ -24,6 +24,7 @@ extern se::Object* __jsb_${current_class.parents[0].underlined_class_name}_proto
 #if not $current_class.is_abstract
 static bool js_${current_class.underlined_class_name}_finalize(se::State& s)
 {
+    #if not $current_class.is_skip_desctructor
     CCLOGINFO("jsbindings: finalizing JS object %p (${current_class.namespaced_class_name})", s.nativeThisObject());
     #if $current_class.is_ref_class
     ${current_class.namespaced_class_name}* cobj = (${current_class.namespaced_class_name}*)s.nativeThisObject();
@@ -38,6 +39,9 @@ static bool js_${current_class.underlined_class_name}_finalize(se::State& s)
         delete cobj;
     }
         #end if
+    #end if
+    #else
+    // destructor is skipped
     #end if
     return true;
 }


### PR DESCRIPTION
- allow skip destructor in `ini` `skip = ` field
- bind a method `*_destroy()` and let `*_finalize()` stay empty