### PR TITLE
ignore constructor

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1032,6 +1032,10 @@ class NativeClass(object):
         self.parse()
 
     @property
+    def is_skip_constructor(self):
+        return self.generator.skip_constructor(self.class_name)
+
+    @property
     def underlined_class_name(self):
         return self.namespaced_class_name.replace("::", "_")
 
@@ -1451,6 +1455,9 @@ class Generator(object):
 
     def rename_destructor(self, class_name):
         return self.should_rename_function(class_name, "~" + class_name)
+
+    def skip_constructor(self, class_name):
+        return self.should_skip(class_name, class_name)
 
     def in_listed_classes(self, class_name):
         """

--- a/targets/spidermonkey/templates/constructor.c
+++ b/targets/spidermonkey/templates/constructor.c
@@ -4,6 +4,11 @@ SE_DECLARE_FINALIZE_FUNC(js_${underlined_class_name}_finalize)
 
 static bool ${signature_name}(se::State& s)
 {
+#if $is_skip_constructor
+    //#3 ${namespaced_class_name}: is_skip_construtor ${is_skip_constructor}
+    se::ScriptEngine::getInstance()->evalString("throw new Error(\"${namespaced_class_name} constructor is skipped\")");
+    return false;
+#else
 #if len($arguments) >= $min_args
     #set arg_count = len($arguments)
     #set arg_idx = $min_args
@@ -44,13 +49,18 @@ static bool ${signature_name}(se::State& s)
     #if $arg_idx > 0
     SE_PRECONDITION2(ok, false, "${signature_name} : Error processing arguments");
     #end if
-    #set $arg_list = ", ".join($arg_array)
-    ${namespaced_class_name}* cobj = new (std::nothrow) ${namespaced_class_name}($arg_list);
+    #if len($arg_array) == 0
+    #set $arg_list=""
+    #else
+    #set $arg_list = ", " + ", ".join($arg_array)
+    #end if
+    ${namespaced_class_name}* cobj = JSB_ALLOC(${namespaced_class_name}$arg_list);
     s.thisObject()->setPrivateData(cobj);
     #if not $is_ref_class
     se::NonRefNativePtrCreatedByCtorMap::emplace(cobj);
     #end if
 #end if
     return true;
+#end if
 }
 SE_BIND_CTOR(${signature_name}, __jsb_${underlined_class_name}_class, js_${underlined_class_name}_finalize)

--- a/targets/spidermonkey/templates/constructor_overloaded.c
+++ b/targets/spidermonkey/templates/constructor_overloaded.c
@@ -4,6 +4,11 @@ SE_DECLARE_FINALIZE_FUNC(js_${underlined_class_name}_finalize)
 
 static bool ${signature_name}(se::State& s)
 {
+#if $is_skip_constructor
+    //#1 ${namespaced_class_name}: is_skip_construtor ${is_skip_constructor}
+    se::ScriptEngine::getInstance()->evalString("throw new Error(\"${namespaced_class_name} constructor is skipped\")");
+    return false;
+#else
     CC_UNUSED bool ok = true;
     const auto& args = s.args();
     size_t argc = args.size();
@@ -44,8 +49,12 @@ static bool ${signature_name}(se::State& s)
                 #end if
             #end while
         #end if
-        #set $arg_list = ", ".join($arg_array)
-            ${namespaced_class_name}* cobj = new (std::nothrow) ${namespaced_class_name}($arg_list);
+        #if len($arg_array) == 0
+        #set $arg_list=""
+        #else
+        #set $arg_list = ", " + ", ".join($arg_array)
+        #end if
+            ${namespaced_class_name}* cobj = JSB_ALLOC(${namespaced_class_name}$arg_list);
             s.thisObject()->setPrivateData(cobj);
             #if not $is_ref_class
             se::NonRefNativePtrCreatedByCtorMap::emplace(cobj);
@@ -59,5 +68,6 @@ static bool ${signature_name}(se::State& s)
 #end for
     SE_REPORT_ERROR("wrong number of arguments: %d", (int)argc);
     return false;
+#end if
 }
 SE_BIND_CTOR(${signature_name}, __jsb_${underlined_class_name}_class, js_${underlined_class_name}_finalize)

--- a/targets/spidermonkey/templates/ctor.c
+++ b/targets/spidermonkey/templates/ctor.c
@@ -2,6 +2,11 @@
 
 static bool ${signature_name}(se::State& s)
 {
+#if $is_skip_constructor
+    //#2 ${namespaced_class_name}: is_skip_construtor ${is_skip_constructor}
+    se::ScriptEngine::getInstance()->evalString("throw new Error(\"${namespaced_class_name} constructor is skipped\")");
+    return false;
+#else
 #if len($arguments) >= $min_args
     #set arg_count = len($arguments)
     #set arg_idx = $min_args
@@ -43,13 +48,18 @@ static bool ${signature_name}(se::State& s)
     #if $arg_idx > 0
     SE_PRECONDITION2(ok, false, "${signature_name} : Error processing arguments");
     #end if
-    #set $arg_list = ", ".join($arg_array)
-    ${namespaced_class_name}* cobj = new (std::nothrow) ${namespaced_class_name}($arg_list);
+    #if len($arg_array) == 0
+    #set $arg_list=""
+    #else
+    #set $arg_list = "," + ", ".join($arg_array)
+    #end if
+    ${namespaced_class_name}* cobj = JSB_ALLOC(${namespaced_class_name}$arg_list);
     s.thisObject()->setPrivateData(cobj);
     #if not $is_ref_class
     se::NonRefNativePtrCreatedByCtorMap::emplace(cobj);
     #end if
 #end if
     return true;
+#end if
 }
 SE_BIND_SUB_CLS_CTOR(${signature_name}, __jsb_${underlined_class_name}_class, js_${underlined_class_name}_finalize)

--- a/targets/spidermonkey/templates/layout_head.c
+++ b/targets/spidermonkey/templates/layout_head.c
@@ -23,3 +23,10 @@ $macro_judgement
 #end for
 #end if
 
+#ifndef JSB_ALLOC
+#define JSB_ALLOC(kls, ...) new (std::nothrow) kls(__VA_ARGS__)
+#endif
+
+#ifndef JSB_FREE
+#define JSB_FREE(ptr) delete ptr
+#endif

--- a/targets/spidermonkey/templates/register.c
+++ b/targets/spidermonkey/templates/register.c
@@ -36,7 +36,7 @@ static bool js_${current_class.underlined_class_name}_finalize(se::State& s)
     {
         se::NonRefNativePtrCreatedByCtorMap::erase(iter);
         ${current_class.namespaced_class_name}* cobj = (${current_class.namespaced_class_name}*)s.nativeThisObject();
-        delete cobj;
+        JSB_FREE(cobj);
     }
         #end if
     #end if
@@ -62,7 +62,7 @@ static bool js_${current_class.underlined_class_name}_${current_class.rename_des
     {
         se::NonRefNativePtrCreatedByCtorMap::erase(iter);
         ${current_class.namespaced_class_name}* cobj = (${current_class.namespaced_class_name}*)s.nativeThisObject();
-        delete cobj;
+        JSB_FREE(cobj);
     }
         #end if
     #end if


### PR DESCRIPTION
ref https://github.com/cocos-creator/3d-tasks/issues/2280

--- 
- 调用 被 `skip` 的构造函数会在 `js` 层抛出异常
- 通过定义 `JSB_ALLOC/JSB_FREE` 可以替代 `new/delete`
