### PR TITLE
fix windows line endings

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1562,8 +1562,8 @@ class Generator(object):
         implfilepath = os.path.join(self.outdir, self.out_file + ".cpp")
         headfilepath = os.path.join(self.outdir, self.out_file + ".hpp")
 
-        self.impl_file = open(implfilepath, "w+")
-        self.head_file = open(headfilepath, "w+")
+        self.impl_file = open(implfilepath, "wb+")
+        self.head_file = open(headfilepath, "wb+")
 
         layout_h = Template(file=os.path.join(self.target, "templates", "layout_head.h"),
                             searchList=[self])


### PR DESCRIPTION
python2 需要用二进制模式，否则 windows 上输出行尾都是 \r\n